### PR TITLE
#40: new implementation of simple input for Android, move floating label input factory to separate class

### DIFF
--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2020 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package dev.icerock.moko.widgets.factory

--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package dev.icerock.moko.widgets.factory
 
 import android.R

--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
@@ -5,14 +5,14 @@
 package dev.icerock.moko.widgets.factory
 
 import android.annotation.SuppressLint
-import android.content.res.ColorStateList
-import android.graphics.Typeface
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.LinearLayout
 import androidx.core.view.MarginLayoutParamsCompat
+import dev.icerock.moko.graphics.Color
+import dev.icerock.moko.graphics.colorInt
 import dev.icerock.moko.widgets.InputWidget
 import dev.icerock.moko.widgets.core.ViewBundle
 import dev.icerock.moko.widgets.core.ViewFactory
@@ -33,7 +33,7 @@ actual class SystemInputViewFactory actual constructor(
     private val margins: MarginValues?,
     private val padding: PaddingValues?,
     private val textStyle: TextStyle?,
-    private val labelTextStyle: TextStyle?,
+    private val labelTextColor: Color?,
     private val textAlignment: TextAlignment?
 ) : ViewFactory<InputWidget<out WidgetSize>> {
 
@@ -89,22 +89,9 @@ actual class SystemInputViewFactory actual constructor(
                     widget.field.data.value = s.toString()
                 }
             })
-        }
 
-        labelTextStyle?.also {
-            if (it.color != null) {
-                val hintColor = ColorStateList.valueOf(it.color.argb.toInt())
-                editText.setHintTextColor(hintColor)
-            }
-            if (it.size != null) {
-                editText.textSize = it.size.toFloat().sp(context)
-            }
-            if(it.fontStyle != null) {
-                editText.typeface = when(it.fontStyle) {
-                    FontStyle.BOLD -> Typeface.DEFAULT_BOLD
-                    FontStyle.MEDIUM -> Typeface.DEFAULT
-                }
-            }
+            // setting hint text color
+            labelTextColor?.let { setHintTextColor(it.colorInt()) }
         }
 
         widget.field.data.bind(lifecycleOwner) { data ->

--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/style/ext/TextAlignmentExt.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/style/ext/TextAlignmentExt.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package dev.icerock.moko.widgets.style.ext
 
 import android.view.Gravity

--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/style/ext/TextAlignmentExt.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/style/ext/TextAlignmentExt.kt
@@ -1,0 +1,10 @@
+package dev.icerock.moko.widgets.style.ext
+
+import android.view.Gravity
+import dev.icerock.moko.widgets.style.view.TextAlignment
+
+fun TextAlignment.getGravity() = when(this) {
+    TextAlignment.LEFT -> Gravity.START
+    TextAlignment.RIGHT -> Gravity.END
+    TextAlignment.CENTER -> Gravity.CENTER
+}

--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/style/ext/TextAlignmentExt.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/style/ext/TextAlignmentExt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2020 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package dev.icerock.moko.widgets.style.ext

--- a/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
+++ b/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package dev.icerock.moko.widgets.factory
 
 import dev.icerock.moko.graphics.Color

--- a/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
+++ b/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2020 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package dev.icerock.moko.widgets.factory

--- a/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
+++ b/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
@@ -1,7 +1,3 @@
-/*
- * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
- */
-
 package dev.icerock.moko.widgets.factory
 
 import dev.icerock.moko.graphics.Color
@@ -10,11 +6,14 @@ import dev.icerock.moko.widgets.core.ViewFactory
 import dev.icerock.moko.widgets.style.background.Background
 import dev.icerock.moko.widgets.style.view.*
 
-expect class SystemInputViewFactory(
+expect class FloatingLabelInputViewFactory(
     background: Background? = null,
     margins: MarginValues? = null,
     padding: PaddingValues? = null,
     textStyle: TextStyle? = null,
     labelTextStyle: TextStyle? = null,
+    errorTextStyle: TextStyle? = null,
+    underLineColor: Color? = null,
+    underLineFocusedColor: Color? = null,
     textAlignment: TextAlignment? = null
 ) : ViewFactory<InputWidget<out WidgetSize>>

--- a/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
+++ b/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
@@ -15,6 +15,6 @@ expect class SystemInputViewFactory(
     margins: MarginValues? = null,
     padding: PaddingValues? = null,
     textStyle: TextStyle? = null,
-    labelTextStyle: TextStyle? = null,
+    labelTextColor: Color? = null,
     textAlignment: TextAlignment? = null
 ) : ViewFactory<InputWidget<out WidgetSize>>

--- a/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
+++ b/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package dev.icerock.moko.widgets.factory
 
 import dev.icerock.moko.graphics.Color

--- a/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
+++ b/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2020 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package dev.icerock.moko.widgets.factory

--- a/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
+++ b/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
@@ -1,7 +1,3 @@
-/*
- * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
- */
-
 package dev.icerock.moko.widgets.factory
 
 import dev.icerock.moko.graphics.Color
@@ -51,12 +47,15 @@ import platform.UIKit.topAnchor
 import platform.UIKit.trailingAnchor
 import platform.UIKit.translatesAutoresizingMaskIntoConstraints
 
-actual class SystemInputViewFactory actual constructor(
+actual class FloatingLabelInputViewFactory actual constructor(
     private val background: Background?,
     private val margins: MarginValues?,
     private val padding: PaddingValues?,
     private val textStyle: TextStyle?,
     private val labelTextStyle: TextStyle?,
+    private val errorTextStyle: TextStyle?,
+    private val underLineColor: Color?,
+    private val underLineFocusedColor: Color?,
     private val textAlignment: TextAlignment?
 ) : ViewFactory<InputWidget<out WidgetSize>> {
 
@@ -80,7 +79,14 @@ actual class SystemInputViewFactory actual constructor(
             applyBackgroundIfNeeded(background)
 
             applyTextStyleIfNeeded(textStyle)
+            applyErrorStyleIfNeeded(errorTextStyle)
             applyLabelStyleIfNeeded(labelTextStyle)
+            underLineColor?.let {
+                deselectedColor = it.toUIColor()
+            }
+            underLineFocusedColor?.let {
+                selectedColor = it.toUIColor()
+            }
 
             textChanged = { newValue ->
                 val currentValue = widget.field.data.value
@@ -325,4 +331,5 @@ actual class SystemInputViewFactory actual constructor(
             CATransaction.commit()
         }
     }
+
 }

--- a/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
+++ b/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
@@ -56,8 +56,8 @@ actual class SystemInputViewFactory actual constructor(
     private val margins: MarginValues?,
     private val padding: PaddingValues?,
     private val textStyle: TextStyle?,
-    private val labelTextStyle: TextStyle?,
-    private val textAlignment: TextAlignment?
+    private val labelTextColor: Color?, // TODO: create applying hint text color
+    private val textAlignment: TextAlignment? // TODO: create applying text alignment
 ) : ViewFactory<InputWidget<out WidgetSize>> {
 
     override fun <WS : WidgetSize> build(
@@ -80,7 +80,8 @@ actual class SystemInputViewFactory actual constructor(
             applyBackgroundIfNeeded(background)
 
             applyTextStyleIfNeeded(textStyle)
-            applyLabelStyleIfNeeded(labelTextStyle)
+            // TODO: add [labelTextColor] applying
+            //applyLabelStyleIfNeeded(labelTextStyle)
 
             textChanged = { newValue ->
                 val currentValue = widget.field.data.value


### PR DESCRIPTION
#40 
* Moves old `SystemInputViewFactory` implementation to new `FloatingLabelInputViewFactory` class.
* Text alignment argument was added to `FloatingLabelInputViewFactory`.
* Recreation of `SystemInputViewFactory` - factory for simple text input without floating hint label and highlighting of errors (only Android implementation)
* Arguments (`errorTextStyle`, `underLineColor`, `underLineFocusedColor`) was removed from `SystemInputViewFactory`, textAlignment argument was added to `SystemInputViewFactory`.
