### PR TITLE
#40: separate TextAlignment to horizontal and vertical

### DIFF
--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
@@ -42,7 +42,7 @@ actual class FloatingLabelInputViewFactory actual constructor(
     private val errorTextStyle: TextStyle?,
     private val underLineColor: Color?,
     private val underLineFocusedColor: Color?,
-    private val textAlignment: TextAlignment?
+    private val textHorizontalAlignment: TextHorizontalAlignment?
 ) : ViewFactory<InputWidget<out WidgetSize>> {
 
     @SuppressLint("RestrictedApi")
@@ -77,7 +77,7 @@ actual class FloatingLabelInputViewFactory actual constructor(
             applyTextStyleIfNeeded(textStyle)
             widget.inputType?.also { applyInputType(it) }
 
-            this@FloatingLabelInputViewFactory.textAlignment?.let {
+            this@FloatingLabelInputViewFactory.textHorizontalAlignment?.let {
                 gravity = it.getGravity()
             }
 

--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
@@ -22,11 +22,10 @@ import dev.icerock.moko.widgets.style.applyInputType
 import dev.icerock.moko.widgets.style.applyPaddingIfNeeded
 import dev.icerock.moko.widgets.style.applyTextStyleIfNeeded
 import dev.icerock.moko.widgets.style.background.Background
-import dev.icerock.moko.widgets.style.ext.getGravity
+import dev.icerock.moko.widgets.style.ext.getGravityForTextAlignment
 import dev.icerock.moko.widgets.style.view.*
 import dev.icerock.moko.widgets.utils.bind
 import dev.icerock.moko.widgets.utils.dp
-import dev.icerock.moko.widgets.utils.sp
 
 actual class SystemInputViewFactory actual constructor(
     private val background: Background?,
@@ -34,7 +33,8 @@ actual class SystemInputViewFactory actual constructor(
     private val padding: PaddingValues?,
     private val textStyle: TextStyle?,
     private val labelTextColor: Color?,
-    private val textAlignment: TextAlignment?
+    private val textHorizontalAlignment: TextHorizontalAlignment?,
+    private val textVerticalAlignment: TextVerticalAlignment?
 ) : ViewFactory<InputWidget<out WidgetSize>> {
 
     @SuppressLint("RestrictedApi")
@@ -66,9 +66,10 @@ actual class SystemInputViewFactory actual constructor(
             applyTextStyleIfNeeded(textStyle)
             widget.inputType?.also { applyInputType(it) }
 
-            this@SystemInputViewFactory.textAlignment?.let {
-                gravity = it.getGravity()
-            }
+            gravity = getGravityForTextAlignment(
+                this@SystemInputViewFactory.textHorizontalAlignment,
+                this@SystemInputViewFactory.textVerticalAlignment
+            )
 
             setOnFocusChangeListener { _, hasFocus ->
                 if (!hasFocus) widget.field.validate()

--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/SystemTextViewFactory.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/factory/SystemTextViewFactory.kt
@@ -15,7 +15,7 @@ import dev.icerock.moko.widgets.style.applyBackgroundIfNeeded
 import dev.icerock.moko.widgets.style.applyTextStyleIfNeeded
 import dev.icerock.moko.widgets.style.background.Background
 import dev.icerock.moko.widgets.style.view.MarginValues
-import dev.icerock.moko.widgets.style.view.TextAlignment
+import dev.icerock.moko.widgets.style.view.TextHorizontalAlignment
 import dev.icerock.moko.widgets.style.view.TextStyle
 import dev.icerock.moko.widgets.style.view.WidgetSize
 import dev.icerock.moko.widgets.utils.bind
@@ -23,7 +23,7 @@ import dev.icerock.moko.widgets.utils.bind
 actual class SystemTextViewFactory actual constructor(
     private val background: Background?,
     private val textStyle: TextStyle?,
-    private val textAlignment: TextAlignment?,
+    private val textHorizontalAlignment: TextHorizontalAlignment?,
     private val margins: MarginValues?
 ) : ViewFactory<TextWidget<out WidgetSize>> {
 
@@ -40,10 +40,10 @@ actual class SystemTextViewFactory actual constructor(
             applyBackgroundIfNeeded(this@SystemTextViewFactory.background)
 
             @SuppressLint("RtlHardcoded")
-            when (this@SystemTextViewFactory.textAlignment) {
-                TextAlignment.LEFT -> gravity = Gravity.LEFT
-                TextAlignment.CENTER -> gravity = Gravity.CENTER
-                TextAlignment.RIGHT -> gravity = Gravity.RIGHT
+            when (this@SystemTextViewFactory.textHorizontalAlignment) {
+                TextHorizontalAlignment.LEFT -> gravity = Gravity.LEFT
+                TextHorizontalAlignment.CENTER -> gravity = Gravity.CENTER
+                TextHorizontalAlignment.RIGHT -> gravity = Gravity.RIGHT
                 null -> {
                 }
             }

--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/style/ext/TextAlignmentExt.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/style/ext/TextAlignmentExt.kt
@@ -5,10 +5,32 @@
 package dev.icerock.moko.widgets.style.ext
 
 import android.view.Gravity
-import dev.icerock.moko.widgets.style.view.TextAlignment
+import dev.icerock.moko.widgets.style.view.TextHorizontalAlignment
+import dev.icerock.moko.widgets.style.view.TextVerticalAlignment
 
-fun TextAlignment.getGravity() = when(this) {
-    TextAlignment.LEFT -> Gravity.START
-    TextAlignment.RIGHT -> Gravity.END
-    TextAlignment.CENTER -> Gravity.CENTER
+fun TextHorizontalAlignment.getGravity() = when(this) {
+    TextHorizontalAlignment.LEFT -> Gravity.START
+    TextHorizontalAlignment.RIGHT -> Gravity.END
+    TextHorizontalAlignment.CENTER -> Gravity.CENTER_HORIZONTAL
+}
+
+fun TextVerticalAlignment.getGravity() = when(this) {
+    TextVerticalAlignment.TOP -> Gravity.TOP
+    TextVerticalAlignment.MIDDLE -> Gravity.CENTER_VERTICAL
+    TextVerticalAlignment.BOTTOM -> Gravity.BOTTOM
+}
+
+fun getGravityForTextAlignment(
+    textHorizontalAlignment: TextHorizontalAlignment?,
+    textVerticalAlignment: TextVerticalAlignment?
+): Int {
+    return if(textHorizontalAlignment != null && textVerticalAlignment != null) {
+        textHorizontalAlignment.getGravity() or textVerticalAlignment.getGravity()
+    } else if(textHorizontalAlignment != null) {
+        textHorizontalAlignment.getGravity()
+    } else if(textVerticalAlignment != null) {
+        textVerticalAlignment.getGravity()
+    } else {
+        throw IllegalArgumentException("At least one argument must be nonnull.")
+    }
 }

--- a/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
+++ b/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
@@ -19,5 +19,5 @@ expect class FloatingLabelInputViewFactory(
     errorTextStyle: TextStyle? = null,
     underLineColor: Color? = null,
     underLineFocusedColor: Color? = null,
-    textAlignment: TextAlignment? = null
+    textHorizontalAlignment: TextHorizontalAlignment? = null
 ) : ViewFactory<InputWidget<out WidgetSize>>

--- a/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
+++ b/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
@@ -16,5 +16,6 @@ expect class SystemInputViewFactory(
     padding: PaddingValues? = null,
     textStyle: TextStyle? = null,
     labelTextColor: Color? = null,
-    textAlignment: TextAlignment? = null
+    textHorizontalAlignment: TextHorizontalAlignment? = null,
+    textVerticalAlignment: TextVerticalAlignment? = null
 ) : ViewFactory<InputWidget<out WidgetSize>>

--- a/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/SystemTextViewFactory.kt
+++ b/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/factory/SystemTextViewFactory.kt
@@ -8,14 +8,13 @@ import dev.icerock.moko.widgets.TextWidget
 import dev.icerock.moko.widgets.core.ViewFactory
 import dev.icerock.moko.widgets.style.background.Background
 import dev.icerock.moko.widgets.style.view.MarginValues
-import dev.icerock.moko.widgets.style.view.PaddingValues
-import dev.icerock.moko.widgets.style.view.TextAlignment
+import dev.icerock.moko.widgets.style.view.TextHorizontalAlignment
 import dev.icerock.moko.widgets.style.view.TextStyle
 import dev.icerock.moko.widgets.style.view.WidgetSize
 
 expect class SystemTextViewFactory(
     background: Background? = null,
     textStyle: TextStyle? = null,
-    textAlignment: TextAlignment? = null,
+    textHorizontalAlignment: TextHorizontalAlignment? = null,
     margins: MarginValues? = null
 ) : ViewFactory<TextWidget<out WidgetSize>>

--- a/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/style/view/TextHorizontalAlignment.kt
+++ b/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/style/view/TextHorizontalAlignment.kt
@@ -4,7 +4,7 @@
 
 package dev.icerock.moko.widgets.style.view
 
-enum class TextAlignment {
+enum class TextHorizontalAlignment {
     LEFT,
     CENTER,
     RIGHT

--- a/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/style/view/TextVerticalAlignment.kt
+++ b/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/style/view/TextVerticalAlignment.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2020 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.widgets.style.view
+
+enum class TextVerticalAlignment {
+    TOP,
+    MIDDLE,
+    BOTTOM
+}

--- a/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
+++ b/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/FloatingLabelInputViewFactory.kt
@@ -44,7 +44,6 @@ import platform.UIKit.addSubview
 import platform.UIKit.bottomAnchor
 import platform.UIKit.leadingAnchor
 import platform.UIKit.systemFontSize
-import platform.UIKit.systemGray3Color
 import platform.UIKit.systemGrayColor
 import platform.UIKit.systemRedColor
 import platform.UIKit.topAnchor
@@ -60,7 +59,7 @@ actual class FloatingLabelInputViewFactory actual constructor(
     private val errorTextStyle: TextStyle?,
     private val underLineColor: Color?,
     private val underLineFocusedColor: Color?,
-    private val textAlignment: TextAlignment?
+    private val textHorizontalAlignment: TextHorizontalAlignment?
 ) : ViewFactory<InputWidget<out WidgetSize>> {
 
     override fun <WS : WidgetSize> build(

--- a/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
+++ b/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/SystemInputViewFactory.kt
@@ -5,7 +5,6 @@
 package dev.icerock.moko.widgets.factory
 
 import dev.icerock.moko.graphics.Color
-import dev.icerock.moko.graphics.toUIColor
 import dev.icerock.moko.widgets.InputWidget
 import dev.icerock.moko.widgets.core.ViewBundle
 import dev.icerock.moko.widgets.core.ViewFactory
@@ -44,7 +43,6 @@ import platform.UIKit.addSubview
 import platform.UIKit.bottomAnchor
 import platform.UIKit.leadingAnchor
 import platform.UIKit.systemFontSize
-import platform.UIKit.systemGray3Color
 import platform.UIKit.systemGrayColor
 import platform.UIKit.systemRedColor
 import platform.UIKit.topAnchor
@@ -57,7 +55,8 @@ actual class SystemInputViewFactory actual constructor(
     private val padding: PaddingValues?,
     private val textStyle: TextStyle?,
     private val labelTextColor: Color?, // TODO: create applying hint text color
-    private val textAlignment: TextAlignment? // TODO: create applying text alignment
+    private val textHorizontalAlignment: TextHorizontalAlignment?, // TODO: create applying text alignment
+    private val textVerticalAlignment: TextVerticalAlignment? // TODO: create applying text alignment
 ) : ViewFactory<InputWidget<out WidgetSize>> {
 
     override fun <WS : WidgetSize> build(

--- a/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/SystemTextViewFactory.kt
+++ b/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/factory/SystemTextViewFactory.kt
@@ -10,7 +10,7 @@ import dev.icerock.moko.widgets.core.ViewFactory
 import dev.icerock.moko.widgets.core.ViewFactoryContext
 import dev.icerock.moko.widgets.style.background.Background
 import dev.icerock.moko.widgets.style.view.MarginValues
-import dev.icerock.moko.widgets.style.view.TextAlignment
+import dev.icerock.moko.widgets.style.view.TextHorizontalAlignment
 import dev.icerock.moko.widgets.style.view.TextStyle
 import dev.icerock.moko.widgets.style.view.WidgetSize
 import dev.icerock.moko.widgets.utils.applyBackgroundIfNeeded
@@ -30,7 +30,7 @@ import platform.UIKit.translatesAutoresizingMaskIntoConstraints
 actual class SystemTextViewFactory actual constructor(
     private val background: Background?,
     private val textStyle: TextStyle?,
-    private val textAlignment: TextAlignment?,
+    private val textHorizontalAlignment: TextHorizontalAlignment?,
     private val margins: MarginValues?
 ) : ViewFactory<TextWidget<out WidgetSize>> {
 
@@ -49,10 +49,10 @@ actual class SystemTextViewFactory actual constructor(
             setContentCompressionResistancePriority(749f, UILayoutConstraintAxisHorizontal)
             setContentCompressionResistancePriority(749f, UILayoutConstraintAxisVertical)
 
-            when (this@SystemTextViewFactory.textAlignment) {
-                TextAlignment.LEFT -> textAlignment = NSTextAlignmentLeft
-                TextAlignment.CENTER -> textAlignment = NSTextAlignmentCenter
-                TextAlignment.RIGHT -> textAlignment = NSTextAlignmentRight
+            when (this@SystemTextViewFactory.textHorizontalAlignment) {
+                TextHorizontalAlignment.LEFT -> textAlignment = NSTextAlignmentLeft
+                TextHorizontalAlignment.CENTER -> textAlignment = NSTextAlignmentCenter
+                TextHorizontalAlignment.RIGHT -> textAlignment = NSTextAlignmentRight
                 null -> {
                 }
             }


### PR DESCRIPTION
Separate `TextAlignment` enum to `TextHorizontalAlignment` and `TextVerticalAlignment` enums.