### PR TITLE
#56 NavBar android selected tab fix

### DIFF
--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/screen/navigation/BottomNavigationScreen.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/screen/navigation/BottomNavigationScreen.kt
@@ -73,6 +73,7 @@ actual abstract class BottomNavigationScreen actual constructor(
             menuItemAction[menuItem]?.invoke()
             true
         }
+        
         bottomNavigationView = bottomNavigation
 
         return LinearLayout(context).apply {

--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/screen/navigation/BottomNavigationScreen.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/screen/navigation/BottomNavigationScreen.kt
@@ -17,7 +17,6 @@ import dev.icerock.moko.graphics.Color
 import dev.icerock.moko.widgets.screen.Args
 import dev.icerock.moko.widgets.screen.FragmentNavigation
 import dev.icerock.moko.widgets.screen.Screen
-import dev.icerock.moko.widgets.screen.ScreenFactory
 import dev.icerock.moko.widgets.utils.ThemeAttrs
 import dev.icerock.moko.widgets.utils.dp
 
@@ -65,6 +64,7 @@ actual abstract class BottomNavigationScreen actual constructor(
 
             menuItemAction[menuItem] = {
                 val instance = item.screenDesc.instantiate()
+                selectedItemId = item.id
                 fragmentNavigation.routeToScreen(instance)
             }
         }
@@ -75,6 +75,7 @@ actual abstract class BottomNavigationScreen actual constructor(
         }
 
         bottomNavigationView = bottomNavigation
+        bottomNavigationView?.selectedItemId = selectedItemId
 
         return LinearLayout(context).apply {
             layoutParams = ViewGroup.LayoutParams(
@@ -126,11 +127,7 @@ actual abstract class BottomNavigationScreen actual constructor(
         router.bottomNavigationScreen = null
     }
 
-    actual var selectedItemId: Int
-        get() = bottomNavigationView?.selectedItemId ?: -1
-        set(value) {
-            bottomNavigationView?.selectedItemId = value
-        }
+    actual var selectedItemId: Int = -1
 
     actual var bottomNavigationColor: Color? = null
         set(value) {

--- a/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/screen/navigation/BottomNavigationScreen.kt
+++ b/widgets/src/androidMain/kotlin/dev/icerock/moko/widgets/screen/navigation/BottomNavigationScreen.kt
@@ -45,6 +45,7 @@ actual abstract class BottomNavigationScreen actual constructor(
             id = android.R.id.content
         }
         val bottomNavigation = BottomNavigationView(context).apply {
+            id = android.R.id.tabs
             ViewCompat.setElevation(this, 8.dp(context).toFloat())
             val color = bottomNavigationColor
             if (color != null) {
@@ -64,7 +65,6 @@ actual abstract class BottomNavigationScreen actual constructor(
 
             menuItemAction[menuItem] = {
                 val instance = item.screenDesc.instantiate()
-                selectedItemId = item.id
                 fragmentNavigation.routeToScreen(instance)
             }
         }
@@ -73,9 +73,7 @@ actual abstract class BottomNavigationScreen actual constructor(
             menuItemAction[menuItem]?.invoke()
             true
         }
-
         bottomNavigationView = bottomNavigation
-        bottomNavigationView?.selectedItemId = selectedItemId
 
         return LinearLayout(context).apply {
             layoutParams = ViewGroup.LayoutParams(
@@ -127,7 +125,11 @@ actual abstract class BottomNavigationScreen actual constructor(
         router.bottomNavigationScreen = null
     }
 
-    actual var selectedItemId: Int = -1
+    actual var selectedItemId: Int
+        get() = bottomNavigationView?.selectedItemId ?: -1
+        set(value) {
+            bottomNavigationView?.selectedItemId = value
+        }
 
     actual var bottomNavigationColor: Color? = null
         set(value) {


### PR DESCRIPTION
When you return to the screen through createPopRoute (), the NavBar forgets on which tab it was open and is reset to the first one. This is due to being recreated bottomNavigationView,
and the id of the previously opened tab is not saved anywhere.