### PR TITLE
fixed secureTextEntry for input type on iOS

### DIFF
--- a/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/style/InputTypes.kt
+++ b/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/style/InputTypes.kt
@@ -19,7 +19,7 @@ fun UITextField.applyInputTypeIfNeeded(
 ) {
     if (type == null) return
     this.keyboardType = type.toPlatformInputType()
-    this.secureTextEntry = type == InputType.Password()
+    this.secureTextEntry = type is InputType.Password
 }
 
 private fun InputType.toPlatformInputType(): UIKeyboardType {


### PR DESCRIPTION
was broken after change InputType to sealed class 