### PR TITLE
Sync scroll of list when resizing view by keyboard showing

### DIFF
--- a/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/core/screen/WidgetScreen.kt
+++ b/widgets/src/commonMain/kotlin/dev/icerock/moko/widgets/core/screen/WidgetScreen.kt
@@ -13,4 +13,5 @@ expect abstract class WidgetScreen<Arg : Args>() : Screen<Arg> {
 
     open val isKeyboardResizeContent: Boolean
     open val isDismissKeyboardOnTap: Boolean
+    open val isScrollListOnKeyboardResize: Boolean
 }

--- a/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/core/screen/WidgetScreen.kt
+++ b/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/core/screen/WidgetScreen.kt
@@ -20,4 +20,5 @@ actual abstract class WidgetScreen<Arg : Args> actual constructor() : Screen<Arg
 
     actual open val isKeyboardResizeContent: Boolean = false
     actual open val isDismissKeyboardOnTap: Boolean = false
+    actual open val isScrollListOnKeyboardResize: Boolean = false
 }


### PR DESCRIPTION
Sync scroll of list when resizing view by keyboard showing. It means, after keyboard shown/hide, scroll bottom offset will be same as before. Like in chats(WathsApp, Telegram,...)