### PR TITLE
Fix iOS background update performance issues

### DIFF
--- a/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/core/utils/BackgroundExt.kt
+++ b/widgets/src/iosMain/kotlin/dev/icerock/moko/widgets/core/utils/BackgroundExt.kt
@@ -13,13 +13,13 @@ import dev.icerock.moko.widgets.core.objc.cgColors
 import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSRunLoop
+import platform.Foundation.NSRunLoopCommonModes
+import platform.QuartzCore.CADisplayLink
 import platform.QuartzCore.CAGradientLayer
 import platform.QuartzCore.CALayer
 import platform.QuartzCore.CATransaction
-import platform.UIKit.UIButton
-import platform.UIKit.UIColor
-import platform.UIKit.UIView
-import platform.UIKit.backgroundColor
+import platform.UIKit.*
 
 fun Background<out Fill>.caLayer(): CALayer {
 
@@ -105,19 +105,26 @@ fun UIButton.applyStateBackgroundIfNeeded(background: PressableState<Background<
     updateLayers()
 
     // FIXME memoryleak, perfomance problem !!!
-    displayLink {
-        val (width, height) = layer.bounds.useContents { size.width to size.height }
+    var link: CADisplayLink? = null
 
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
+    link = displayLink {
+        if (window != null) {
+            val (width, height) = layer.bounds.useContents { size.width to size.height }
 
-        normalBg.frame = CGRectMake(0.0, 0.0, width, height)
-        disabledBg.frame = CGRectMake(0.0, 0.0, width, height)
-        pressedBg.frame = CGRectMake(0.0, 0.0, width, height)
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
 
-        updateLayers()
+            normalBg.frame = CGRectMake(0.0, 0.0, width, height)
+            disabledBg.frame = CGRectMake(0.0, 0.0, width, height)
+            pressedBg.frame = CGRectMake(0.0, 0.0, width, height)
 
-        CATransaction.commit()
+            updateLayers()
+
+            CATransaction.commit()
+
+        } else {
+            link?.removeFromRunLoop(NSRunLoop.currentRunLoop, NSRunLoopCommonModes)
+        }
     }
 }
 
@@ -141,14 +148,20 @@ fun UIView.applyBackgroundIfNeeded(background: Background<out Fill>?) {
     layer.insertSublayer(bgLayer, 0U)
 
     // FIXME memoryleak, perfomance problem !!!
-    displayLink {
-        val (width, height) = layer.bounds.useContents { size.width to size.height }
+    var link: CADisplayLink? = null
 
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
+    link = displayLink {
+        if (window != null) {
+            val (width, height) = layer.bounds.useContents { size.width to size.height }
 
-        bgLayer.frame = CGRectMake(0.0, 0.0, width, height)
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
 
-        CATransaction.commit()
+            bgLayer.frame = CGRectMake(0.0, 0.0, width, height)
+
+            CATransaction.commit()
+        } else {
+            link?.removeFromRunLoop(NSRunLoop.currentRunLoop, NSRunLoopCommonModes)
+        }
     }
 }


### PR DESCRIPTION
This avoids the memory leak / high CPU usage from an indefinite number of `CADisplayLink` being added to `NSRunLoop.currentRunLoop`.

It does this by removing the `CADisplayLink` from the loop when the `UIView` is offscreen (`window` is `null`).